### PR TITLE
Fixes slow jps resolutions

### DIFF
--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(pathfinder)
 	name = "Pathfinder"
 	init_order = INIT_ORDER_PATH
 	priority = FIRE_PRIORITY_PATHFINDING
+	wait = 0.5 // fire as fast as you can bestie
 	/// List of pathfind datums we are currently trying to process
 	var/list/datum/pathfind/active_pathing = list()
 	/// List of pathfind datums being ACTIVELY processed. exists to make subsystem stats readable


### PR DESCRIPTION
The pathfinding subsystem runs on default wait, IE 20ds. This is stupid, and adds random delay to path resolution.
I could make it ticker but that seems wrong. I just moved it to 0.5 so it matches tick lag

This brought resolution times from 10ds to 1, but it can still go lower. As things currently work, jps move loops sleep to await updates from the pathfinder subsystem
This is fine for most uses, but it's not needed here. Can be replaced with a callback, and it'll be a tick faster since we don't need to wait until the next tick for the sleep to wear off.
It's faster too, since sleeps have overhead and can clog the MC
